### PR TITLE
Convert to z1 global counter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 *.sln.docstates
+.vs/
 
 # Build results
 [Dd]ebug/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## LiveSplit.Counter
-A Simple counter component for LiveSplit. 
+A Simple counter component for LiveSplit, customized for "The Legend of Zelda" Global Tracking. 
 
 ## Packages / Requirements
 

--- a/UI/Components/Counter.cs
+++ b/UI/Components/Counter.cs
@@ -2,7 +2,7 @@
 {
     public class Counter : ICounter
     {
-        private int increment = 1;
+        protected int increment = 1;
         private int initialValue = 0;
 
         /// <summary>
@@ -22,7 +22,7 @@
         /// <summary>
         /// Increments this instance.
         /// </summary>
-        public bool Increment()
+        public virtual bool Increment()
         {
             if (Count == int.MaxValue)
                 return false;
@@ -43,7 +43,7 @@
         /// <summary>
         /// Decrements this instance.
         /// </summary>
-        public bool Decrement()
+        public virtual bool Decrement()
         {
             if (Count == int.MinValue)
                 return false;
@@ -72,7 +72,7 @@
         /// <summary>
         /// Sets the count.
         /// </summary>
-        public void SetCount(int value)
+        public virtual void SetCount(int value)
         {
             Count = value;
         }
@@ -84,6 +84,37 @@
         public void SetIncrement(int incrementValue)
         {
             increment = incrementValue;
+        }
+    }
+
+    public class GlobalCounter : Counter
+    {
+        public override bool Decrement()
+        {
+            var newValue = (Count - increment) % 10;
+            SetCount(newValue);
+            return true;
+        }
+
+        public override bool Increment()
+        {
+            var newValue = (Count + increment) % 10;
+            SetCount(newValue);
+            return true;
+        }
+
+        public override void SetCount(int value)
+        {
+            if (value < 0)
+            {
+                value = 0;
+            }
+            else if (value > 9)
+            {
+                value = 9;
+            }
+
+            base.SetCount(value);
         }
     }
 

--- a/UI/Components/CounterComponent.cs
+++ b/UI/Components/CounterComponent.cs
@@ -16,7 +16,7 @@ namespace LiveSplit.UI.Components
             Settings = new CounterComponentSettings();
             Cache = new GraphicsCache();
             CounterNameLabel = new SimpleLabel();
-            Counter = new Counter();
+            Counter = new GlobalCounter();
             this.state = state;
             Settings.CounterReinitialiseRequired += Settings_CounterReinitialiseRequired;
             Settings.IncrementUpdateRequired += Settings_IncrementUpdateRequired;


### PR DESCRIPTION
Implement a `GlobalCounter`, mostly via inheriting from `Counter`, and using it in place of `Counter` within the component.

It should:

- Limit your count to 0-9
- Not let you set a value outside those bounds
- No unit tests :(